### PR TITLE
fix: Add error handling to ans profile fetch

### DIFF
--- a/src/hooks/useAns.ts
+++ b/src/hooks/useAns.ts
@@ -16,20 +16,26 @@ export default function useAns() {
         return setAns(undefined);
       }
 
-      const res = await fetch(
-        `https://ans-stats.decent.land/profile/${address}`
-      );
-      const data: AnsProfile = await res.json();
+      try {
+        const res = await fetch(
+          `https://ans-stats.decent.land/profile/${address}`
+        );
+        const data: AnsProfile = await res.json();
 
-      if (!data?.currentLabel) {
-        return setAns(undefined);
+        if (!data?.currentLabel) {
+          return setAns(undefined);
+        }
+
+        setAns({
+          ...data,
+          currentLabel: data.currentLabel + ".ar",
+          avatar: data.avatar ? `${gatewayURL}/${data.avatar}` : undefined
+        });
+      } catch (e: any) {
+        console.error(
+          `[Arweave Wallet Kit] Failed to fetch ans profile\n${e?.message || e}`
+        );
       }
-
-      setAns({
-        ...data,
-        currentLabel: data.currentLabel + ".ar",
-        avatar: data.avatar ? `${gatewayURL}/${data.avatar}` : undefined
-      });
     })();
   }, [address, gatewayURL]);
 


### PR DESCRIPTION
# Bug

Getting this error on development mode in Next.js when a wallet is connected and the wallet kit tries to fetch the ANS profile. ANS API might not be working and this is throwing the error below.

![image](https://github.com/labscommunity/arweave-wallet-kit/assets/11836100/27d4b438-b79d-4922-84a4-fd95df65459e)

# Fix
Added try catch to ANS profile fetch
