### PR TITLE
fix: othent recursive calls & tags issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "arweave": "^1.12.2",
     "arweave-wallet-connector": "^0.0.31",
     "framer-motion": "^8.1.9",
-    "othent": "^1.0.634",
+    "othent": "^1.0.645",
     "react-helmet": "^6.1.0"
   },
   "devDependencies": {

--- a/src/strategy/strategies/Othent.ts
+++ b/src/strategy/strategies/Othent.ts
@@ -120,12 +120,11 @@ export default class OthentStrategy implements Strategy {
       const res = await othent.userDetails();
 
       if (res.contract_id !== this.#currentAddress) {
+        this.#currentAddress = res.contract_id;
         for (const listener of this.#addressListeners) {
           listener(res.contract_id);
         }
       }
-
-      this.#currentAddress = res.contract_id;
 
       return [
         "ACCESS_ADDRESS",

--- a/src/strategy/strategies/Othent.ts
+++ b/src/strategy/strategies/Othent.ts
@@ -3,6 +3,7 @@ import type { DispatchResult, GatewayConfig, PermissionType } from "arconnect";
 import type Transaction from "arweave/web/lib/transaction";
 import type { AppInfo } from "arweave-wallet-connector";
 import type Strategy from "../Strategy";
+import { decodeTags } from "../../utils";
 import {
   Othent,
   queryWalletAddressTxnsProps,
@@ -176,7 +177,7 @@ export default class OthentStrategy implements Strategy {
     const signedTransaction = await othent.signTransactionArweave({
       othentFunction: "uploadData",
       data: transaction.data,
-      tags: transaction.tags ? transaction.tags : []
+      tags: decodeTags(transaction.tags)
     });
 
     return signedTransaction;
@@ -228,10 +229,12 @@ export default class OthentStrategy implements Strategy {
     try {
       const othent = await this.#othentInstance(false);
 
+      const tags = decodeTags(transaction.tags);
+
       const signedTransaction = await othent.signTransactionBundlr({
         othentFunction: "uploadData",
         data: transaction.data,
-        tags: transaction.tags ? transaction.tags : []
+        tags
       });
 
       const res = await othent.sendTransactionBundlr(signedTransaction);
@@ -245,7 +248,7 @@ export default class OthentStrategy implements Strategy {
           const signedTransaction = await othent.signTransactionArweave({
             othentFunction: "uploadData",
             data: transaction.data,
-            tags: transaction.tags ? transaction.tags : []
+            tags
           });
 
           const res = await othent.sendTransactionArweave(signedTransaction);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import type { Tag } from "arweave/web/lib/transaction";
 import type { RGBObject } from "./components/Provider";
 import type { PermissionType } from "arconnect";
 
@@ -61,4 +62,22 @@ export async function callWindowApi(fn: string, params: any[] = []) {
       }
     })
   );
+}
+
+/**
+ * Decode an array of tags
+ *
+ * @param tags An array of tags
+ * @returns An array of decoded tags
+ */
+export function decodeTags(tags: Tag[]) {
+  return tags.map((tag) => {
+    try {
+      const name = tag.get("name", { decode: true, string: true });
+      const value = tag.get("value", { decode: true, string: true });
+      return { name, value };
+    } catch {
+      return tag;
+    }
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,10 +4229,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-hash@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-2.0.1.tgz#46c3732e65a078ea06b8b4ae686db41216f81213"
-  integrity sha512-t4mkp7Vh6MuCZRBf0XLzBOfhkH3nW6YEAotMDSjshVQ1GffCMGdPLSr7pKH0rdXY02jTjAZ7QW2apD0buaZXcQ==
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -6390,14 +6390,14 @@ ora@^5.4.1:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-othent@^1.0.634:
-  version "1.0.634"
-  resolved "https://registry.yarnpkg.com/othent/-/othent-1.0.634.tgz#23b4da0612311d21b2b2ec09a2035deb38b8ba45"
-  integrity sha512-iI96hhd0HJW3b2nPdEsXiTlpl76xWgTAdpR/vcnSA398HUgzGNXIqRWEBh8K7xR6C3YT6kDwCV9wYDRawxJbDg==
+othent@^1.0.645:
+  version "1.0.645"
+  resolved "https://registry.npmjs.org/othent/-/othent-1.0.645.tgz#5bf705ef62a7d82969967158f22a41ac4c4de2f4"
+  integrity sha512-GfVlJle08LZ5dL53+ETyZXfcjCrAx0xF5OCRMr9SoQFznXvY2ckX1SCjdxPa2V45IIEdsLH40x1mifCAE2obzg==
   dependencies:
     "@auth0/auth0-spa-js" "^2.0.4"
     axios "^1.3.4"
-    crypto-hash "^2.0.1"
+    crypto-js "^4.1.1"
     debug "^4.3.4"
     jsrsasign "^10.8.6"
     jwk-to-pem "^2.0.5"


### PR DESCRIPTION
# PR Description

This PR addresses two issues within the Othent strategy implementation:

- **Recursive calls in getPermissions**: `getPermissions` in Othent strategy calls address event listeners within the function. And one of the listener  called `sync` calls the `getPermissions` again and in this way there is recursive calls between `getPermissions` and `sync` function.
- **Tag Decoding**: Tags aren't decoded before sending to othent servers.