### PR TITLE
fix(modal): use non-transform properties to prevent modal from blurring

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -25,18 +25,7 @@ export function Modal({
   return (
     <AnimatePresence>
       {open && (
-        <div
-          key="modal-screen"
-          className="modal-screen"
-          style={{
-            width: "100vw",
-            height: "100vh",
-            position: "fixed",
-            left: 0,
-            top: 0,
-            zIndex: 100000
-          }}
-        >
+        <ModalScreen key="modal-screen" className="modal-screen">
           <BackgroundLayer
             className="modal-background"
             variants={backgroundAnimation}
@@ -64,7 +53,7 @@ export function Modal({
               <ModalContents>{children}</ModalContents>
             </ModalAnimator>
           </ModalAligner>
-        </div>
+        </ModalScreen>
       )}
     </AnimatePresence>
   );
@@ -118,6 +107,15 @@ const radius: Record<Radius, number> = {
   none: 0
 };
 
+const ModalScreen = styled.div`
+  height: 100vh;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 100000;
+`;
+
 const ModalAligner = styled.div`
   height: 100vh;
   display: flex;
@@ -146,6 +144,18 @@ const ModalAnimator = withTheme(styled(motion.div as any)<any>`
   *::-moz-selection {
     background-color: rgba(0, 0, 0, 0.75);
     color: #fff;
+  }
+
+  @media screen and (min-width: 1081px) {
+    max-width: 28vw;
+  }
+
+  @media screen and (min-width: 721px) and (max-width: 1080px) {
+    max-width: 50vw;
+  }
+
+  @media screen and (max-width: 720px) {
+    max-width: 100vw;
   }
 `) as ForwardRefComponent<HTMLDivElement, HTMLMotionProps<"div">>;
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { Radius, withTheme } from "../../theme";
+import { DefaultTheme, Radius, withTheme } from "../../theme";
 import { version } from "../../../package.json";
 import type { PropsWithChildren } from "react";
 import useMobile from "../../hooks/mobile";
@@ -25,32 +25,46 @@ export function Modal({
   return (
     <AnimatePresence>
       {open && (
-        <BackgroundLayer
-          variants={backgroundAnimation}
-          initial="hidden"
-          animate="shown"
-          exit="hidden"
-          transition={{
-            ease: "easeInOut",
-            duration: 0.23
+        <div
+          key="modal-screen"
+          className="modal-screen"
+          style={{
+            width: "100vw",
+            height: "100vh",
+            position: "fixed",
+            left: 0,
+            top: 0,
+            zIndex: 100000
           }}
-          key="bg"
-          onClick={onClose}
         >
-          {!noWatermark && <KitName>Arweave Wallet Kit v{version}</KitName>}
-        </BackgroundLayer>
-      )}
-      {open && (
-        <Wrapper
-          key="modal"
-          className={className}
-          variants={variants || modalAnimation(mobile)}
-          initial="hidden"
-          animate="shown"
-          exit="hidden"
-        >
-          {children}
-        </Wrapper>
+          <BackgroundLayer
+            className="modal-background"
+            variants={backgroundAnimation}
+            initial="hidden"
+            animate="shown"
+            exit="hidden"
+            transition={{
+              ease: "easeInOut",
+              duration: 0.23
+            }}
+            key="bg"
+            onClick={onClose}
+          >
+            {!noWatermark && <KitName>Arweave Wallet Kit v{version}</KitName>}
+          </BackgroundLayer>
+          <ModalAligner key="modal-aligner" className="modal-aligner">
+            <ModalAnimator
+              key="modal-animator"
+              className={"modal-animator " + (className ? " " + className : "")}
+              variants={variants || modalAnimation(mobile)}
+              initial="hidden"
+              animate="shown"
+              exit="hidden"
+            >
+              <ModalContents>{children}</ModalContents>
+            </ModalAnimator>
+          </ModalAligner>
+        </div>
       )}
     </AnimatePresence>
   );
@@ -73,28 +87,30 @@ const BackgroundLayer = styled(motion.div)`
   background-color: rgba(0, 0, 0, 0.4);
 `;
 
-const modalAnimation = (mobile = false): Variants => ({
-  shown: {
-    opacity: 1,
-    translateX: "-50%",
-    translateY: mobile ? "0" : "-50%",
-    transition: {
-      type: "spring",
-      duration: 0.4,
-      delayChildren: 0.2,
-      staggerChildren: 0.05
+const modalAnimation = (mobile = false): Variants => {
+  return {
+    shown: {
+      top: 0,
+      opacity: 1,
+      width: mobile ? "100vw" : "50vw",
+      transition: {
+        type: "spring",
+        duration: 0.4,
+        delayChildren: 0.2,
+        staggerChildren: 0.05
+      }
+    },
+    hidden: {
+      top: "100%",
+      width: mobile ? "100vw" : "50vw",
+      opacity: 0.4, // TODO(crookse) What's the reason for stopping at 0.4? Asking because a pause in animation is seen.
+      transition: {
+        type: "spring",
+        duration: 0.4
+      }
     }
-  },
-  hidden: {
-    opacity: 0.4,
-    translateX: "-50%",
-    translateY: "200%",
-    transition: {
-      type: "spring",
-      duration: 0.4
-    }
-  }
-});
+  };
+};
 
 const radius: Record<Radius, number> = {
   default: 30,
@@ -102,18 +118,25 @@ const radius: Record<Radius, number> = {
   none: 0
 };
 
-const Wrapper = withTheme(styled(motion.div as any)<any>`
-  position: fixed;
-  left: 50%;
-  top: 50%;
-  width: 28vw;
-  background-color: rgb(${(props) => props.theme.background});
-  border-radius: ${(props) =>
-    radius[props.theme.themeConfig.radius as Radius] + "px"};
+const ModalAligner = styled.div`
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  @media screen and (max-width: 720px) {
+    align-items: flex-end;
+  }
+`;
+
+const ModalAnimator = withTheme(styled(motion.div as any)<any>`
+  position: relative;
+  left: 0;
+  top: 100%;
   z-index: 100000;
   font-family: "Manrope", sans-serif;
   overflow: hidden;
-  transition: background-color 0.23s ease-in-out;
+  transition-property: width;
 
   *::selection {
     background-color: rgba(0, 0, 0, 0.75);
@@ -124,19 +147,19 @@ const Wrapper = withTheme(styled(motion.div as any)<any>`
     background-color: rgba(0, 0, 0, 0.75);
     color: #fff;
   }
+`) as ForwardRefComponent<HTMLDivElement, HTMLMotionProps<"div">>;
 
-  @media screen and (max-width: 1080px) {
-    width: 50vw;
-  }
+const ModalContents = withTheme(styled.div<{ theme: DefaultTheme }>`
+  transition: background-color 0.23s ease-in-out;
+  background-color: rgb(${(props) => props.theme.background});
+  border-radius: ${(props) => radius[props.theme.themeConfig.radius] + "px"};
+  width: 100%;
 
   @media screen and (max-width: 720px) {
-    width: 100vw;
-    top: unset;
-    bottom: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
-`) as ForwardRefComponent<HTMLDivElement, HTMLMotionProps<"div">>;
+`);
 
 const KitName = styled.p`
   position: fixed;


### PR DESCRIPTION
## Summary

I noticed the `Modal` component is blurry on some screens while working with the `ConnectButton` component. Looked into it and noticed it uses transform CSS properties. Although using these properties in conjunction with Framer Motion are probably more performant than CPU-rendered methods, I'm proposing we move the `Modal` component away from transform CSS properties and use a combination of width, flexbox, and position CSS properties to create the same effect, but with a higher level of accessibility. Thoughts?

### Changes made

- Removed transform CSS properties
- Combined `BackgroundLayer` and `Wrapper` into a single `ModalScreen` component
  - This change also renames `Wrapper` to `ModalAnimator` discussed in the next bullet below
- Added `ModalAnimator` to only provide animations for the modal
  - The modal contents are now contained in a `ModalContents` component which provides the styles that the `Wrapper` component provided (background color, border radius, etc.)
- Added class names to the components (e.g., `modal-screen`) to identify them faster in dev tools. __Wondering if these names should be more unique?__

### Cons to the above changes

- When the `Modal` changes from desktop to mobile version on window resize events, the animation isn't as smooth as it is in the original implementation. However, my argument for this being an ok thing is users aren't really going to be resizing their windows and seeing this jumpiness from desktop to mobile version all the time.
- Rendering tasks are moved more towards the CPU

## How to test

- Pull down the branch
- Build the lib
- Import the `ConnectButton` component from the built lib
- Test the component in Chrome, Safari, Firefox, etc.
  - Behvaior should be the same as it is in the `main` branch

## Questions

- [I have a TODO on line 95 in the `Modal.tsx` file](https://github.com/labscommunity/arweave-wallet-kit/compare/main...crookse-cl:fix/modal-blur?expand=1#diff-766208c965d34c3bf67b6cf8dc749036c694359ca121365e8e7e27c08454383eR95). I see the opacity stops at 0.4, but it's causing the opacity animation to pause. Wondering if the 0.4 value is intentional as a workaround for something, so I added a comment instead of changing the value.
  - Steps to reproduce the pause are: Click the `ConnectButton` component and immediately click the `BackgroundLayer` component when it appears.
  - It seems the `hidden` variant is applied at the same time the `shown` variant is running and it causes the `Modal` to stay on the screen with a 0.4 opacity.

## Other topics for discussion

- __Reduced Motion__
  - With accessibility in mind, maybe we look into introducing a [reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) version of the modal as well.
- __Mobile viewport orientation accomodation__
  - I noticed the `Modal` component's mobile version is triggered on window width. This means mobile devices oriented in landscape mode might not trigger the mobile version which could cause the `Modal` component to go outside the bounds of the viewport. Maybe we look at:
     - locking the position of the `Modal` component so that it only works in portrait mode;
     - expanding the `Modal` to be the width and height of the entire viewport at specific heights/widths; or
     - some other option to make the `Modal` component more cross-compatible and/or feeling more native to the device it's being shown on