### PR TITLE
Add `batchSignDataItem` to Arconnect Strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/react-dom": "^18.0.10",
     "@types/react-helmet": "^6.1.6",
     "@vitejs/plugin-react": "^3.0.0",
-    "arconnect": "^1.0.3",
+    "arconnect": "^1.0.4",
     "babel-loader": "^8.3.0",
     "prettier": "^2.8.2",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arweave-wallet-kit",
   "private": false,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: ^3.0.0
         version: 3.1.0(vite@4.5.5(@types/node@18.19.54)(terser@5.34.1))
       arconnect:
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^1.0.4
+        version: 1.0.4
       babel-loader:
         specifier: ^8.3.0
         version: 8.4.1(@babel/core@7.25.2)(webpack@5.95.0(esbuild@0.18.20))
@@ -2231,8 +2231,8 @@ packages:
   arconnect@0.4.2:
     resolution: {integrity: sha512-Jkpd4QL3TVqnd3U683gzXmZUVqBUy17DdJDuL/3D9rkysLgX6ymJ2e+sR+xyZF5Rh42CBqDXWNMmCjBXeP7Gbw==}
 
-  arconnect@1.0.3:
-    resolution: {integrity: sha512-A4BTa1hl8SIbAMVUOsIiLwavmCvIMpbEFSem64klDBuBOMoIuEMUPxP5AoUfUxJZwUdL3NhNj584lCWUSGtdyA==}
+  arconnect@1.0.4:
+    resolution: {integrity: sha512-oEJRl2Cci2dSH+IEpdS1XEBqiZ+3OgPRSYWRx6MxDJU3I+NORrfrrjeZLcuruj6YNId5dpr0ROQuVnUrNkpfRg==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -7845,7 +7845,7 @@ snapshots:
     dependencies:
       arweave: 1.15.5
 
-  arconnect@1.0.3: {}
+  arconnect@1.0.4: {}
 
   argparse@1.0.10:
     dependencies:

--- a/src/strategy/strategies/ArConnect.ts
+++ b/src/strategy/strategies/ArConnect.ts
@@ -1,6 +1,7 @@
 import BrowserWalletStrategy from "./BrowserWallet";
 import { callWindowApi } from "../../utils";
 import type Strategy from "../Strategy";
+import type { DataItem } from "arconnect";
 
 export default class ArConnectStrategy
   extends BrowserWalletStrategy
@@ -30,5 +31,9 @@ export default class ArConnectStrategy
 
   public async addToken(id: string): Promise<void> {
     return await callWindowApi("addToken", [id]);
+  }
+
+  public async batchSignDataItem(dataItems: DataItem[]): Promise<ArrayBufferLike[]> {
+    return await callWindowApi("batchSignDataItem", [dataItems]);
   }
 }


### PR DESCRIPTION
This PR adds the `batchSignDataItem` api endpoint to the Arconnect Strategy